### PR TITLE
feat!: return ts-style diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,9 @@ The exported function takes fully resolved path to a test file as an argument an
 ```ts
 assertionCount: number;
 diagnostics: {
-  fileName: string;
-  fileText: string;
-  message: string;
-  line?: number;
-  column?: number;
+  file: ts.SourceFile;
+  messageText: string | ts.DiagnosticMessageChain;
+  start: number;
 }
 ```
 

--- a/source/handleAssertions/makeDiagnostic.ts
+++ b/source/handleAssertions/makeDiagnostic.ts
@@ -1,17 +1,10 @@
 import type * as ts from "@tsd/typescript";
 import type { Diagnostic } from "../types";
 
-export function makeDiagnostic(node: ts.Node, message: string): Diagnostic {
-  const position = node
-    .getSourceFile()
-    .getLineAndCharacterOfPosition(node.getStart());
-  const { fileName, text: fileText } = node.getSourceFile();
-
+export function makeDiagnostic(node: ts.Node, messageText: string): Diagnostic {
   return {
-    fileName,
-    fileText,
-    message,
-    line: position.line + 1,
-    column: position.character + 1,
+    file: node.getSourceFile(),
+    start: node.getStart(),
+    messageText,
   };
 }

--- a/source/parser.ts
+++ b/source/parser.ts
@@ -52,25 +52,13 @@ export function parseErrorAssertionToLocation(
   }
 
   for (const node of nodes) {
-    const { fileName, text: fileText } = node.getSourceFile();
+    const file = node.getSourceFile();
+    const start = node.getStart();
+    const end = node.getEnd();
 
-    const location = {
-      fileName,
-      fileText,
-      start: node.getStart(),
-      end: node.getEnd(),
-    };
+    const location = { fileName: file.fileName, start, end };
 
-    const pos = node
-      .getSourceFile()
-      .getLineAndCharacterOfPosition(node.getStart());
-
-    expectedErrors.set(location, {
-      fileName: location.fileName,
-      fileText: location.fileText,
-      line: pos.line + 1,
-      column: pos.character + 1,
-    });
+    expectedErrors.set(location, { file, start });
   }
 
   return expectedErrors;

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,12 +1,12 @@
 import type * as ts from "@tsd/typescript";
 
 export type Diagnostic = {
-  fileName: string;
-  fileText: string;
-  message: string;
-  line?: number;
-  column?: number;
+  file: ts.SourceFile;
+  messageText: string | ts.DiagnosticMessageChain;
+  start: number;
 };
+
+export type ExpectedError = Omit<Diagnostic, "messageText">;
 
 export type Location = {
   fileName: string;
@@ -18,8 +18,3 @@ export type Handler = (
   typeChecker: ts.TypeChecker,
   nodes: Set<ts.CallExpression>
 ) => Diagnostic[];
-
-export type ExpectedError = Pick<
-  Diagnostic,
-  "fileName" | "fileText" | "line" | "column"
->;

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -3,21 +3,16 @@ import { expect, test } from "@jest/globals";
 import tsd from "../";
 import { fixturePath } from "./utils";
 
-test("returns `fileName`", () => {
+test("returns `ts.SourceFile` object", () => {
   const { diagnostics } = tsd(fixturePath("failing"));
 
   expect(diagnostics).toHaveLength(2);
-  expect(normalize(diagnostics[0].fileName)).toEqual(
+  expect(normalize(diagnostics[0].file.fileName)).toEqual(
     resolve("tests", "failing", "index.test.ts")
   );
-});
 
-test("returns `fileText`", () => {
-  const { diagnostics } = tsd(fixturePath("failing"));
-
-  expect(diagnostics).toHaveLength(2);
-  expect(diagnostics[0].fileText).toEqual(diagnostics[1].fileText);
-  expect(diagnostics[0].fileText).toMatchInlineSnapshot(`
+  expect(diagnostics[0].file.text).toEqual(diagnostics[1].file.text);
+  expect(diagnostics[0].file.text).toMatchInlineSnapshot(`
     "import { expectError, expectType } from \\"../../\\";
     import { makeDate } from \\".\\";
 
@@ -47,15 +42,13 @@ test("failing", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Argument of type 'Date' is not assignable to parameter of type 'string'.",
-      line: 5,
-      column: 20,
+      start: 138,
     },
     {
-      message: "Expected an error, but found none.",
-      line: 7,
-      column: 1,
+      messageText: "Expected an error, but found none.",
+      start: 159,
     },
   ]);
 });
@@ -65,18 +58,16 @@ test("failing-nested", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      fileName: expect.stringContaining("index.test.ts"),
-      message:
+      file: { fileName: expect.stringContaining("index.test.ts") },
+      messageText:
         "Argument of type 'number' is not assignable to parameter of type 'string'.",
-      line: 6,
-      column: 20,
+      start: 136,
     },
     {
-      fileName: expect.stringContaining("nested.ts"),
-      message:
+      file: { fileName: expect.stringContaining("nested.ts") },
+      messageText:
         "Argument of type 'number' is not assignable to parameter of type 'string'.",
-      line: 5,
-      column: 20,
+      start: 117,
     },
   ]);
 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,7 +1,7 @@
 import { normalize, resolve } from "path";
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath } from "./utils";
+import { fixturePath, normalizeDiagnostics } from "./utils";
 
 test("returns `ts.SourceFile` object", () => {
   const { diagnostics } = tsd(fixturePath("failing"));
@@ -40,15 +40,17 @@ test("passing", () => {
 test("failing", () => {
   const { diagnostics } = tsd(fixturePath("failing"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText:
+      message:
         "Argument of type 'Date' is not assignable to parameter of type 'string'.",
-      start: 138,
+      line: 5,
+      character: 20,
     },
     {
-      messageText: "Expected an error, but found none.",
-      start: 159,
+      message: "Expected an error, but found none.",
+      line: 7,
+      character: 1,
     },
   ]);
 });
@@ -56,18 +58,24 @@ test("failing", () => {
 test("failing-nested", () => {
   const { diagnostics } = tsd(fixturePath("failing-nested"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      file: { fileName: expect.stringContaining("index.test.ts") },
-      messageText:
+      file: {
+        fileName: expect.stringContaining("index.test.ts"),
+      },
+      message:
         "Argument of type 'number' is not assignable to parameter of type 'string'.",
-      start: 136,
+      line: 6,
+      character: 20,
     },
     {
-      file: { fileName: expect.stringContaining("nested.ts") },
-      messageText:
+      file: {
+        fileName: expect.stringContaining("nested.ts"),
+      },
+      message:
         "Argument of type 'number' is not assignable to parameter of type 'string'.",
-      start: 117,
+      line: 5,
+      character: 20,
     },
   ]);
 });

--- a/tests/assignable.test.ts
+++ b/tests/assignable.test.ts
@@ -1,22 +1,11 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath } from "./utils";
+import { fixturePath, normalizeDiagnostics } from "./utils";
 
 test("expectAssignable", () => {
   const { diagnostics } = tsd(fixturePath("expectAssignable"));
 
-  const normalizedDiagnostics = diagnostics.map((diagnostic) => {
-    const { character, line } = diagnostic.file.getLineAndCharacterOfPosition(
-      diagnostic.start
-    );
-    return {
-      character: character + 1,
-      line: line + 1,
-      message: diagnostic.messageText,
-    };
-  });
-
-  expect(normalizedDiagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
       message:
         "Argument of type 'string' is not assignable to parameter of type 'boolean'.",
@@ -29,18 +18,7 @@ test("expectAssignable", () => {
 test("expectNotAssignable", () => {
   const { diagnostics } = tsd(fixturePath("expectNotAssignable"));
 
-  const normalizedDiagnostics = diagnostics.map((diagnostic) => {
-    const { character, line } = diagnostic.file.getLineAndCharacterOfPosition(
-      diagnostic.start
-    );
-    return {
-      character: character + 1,
-      line: line + 1,
-      message: diagnostic.messageText,
-    };
-  });
-
-  expect(normalizedDiagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
       message:
         "Argument of type 'string' is assignable to parameter of type 'string | number'.",

--- a/tests/assignable.test.ts
+++ b/tests/assignable.test.ts
@@ -5,11 +5,23 @@ import { fixturePath } from "./utils";
 test("expectAssignable", () => {
   const { diagnostics } = tsd(fixturePath("expectAssignable"));
 
-  expect(diagnostics).toMatchObject([
+  const normalizedDiagnostics = diagnostics.map((diagnostic) => {
+    const { character, line } = diagnostic.file.getLineAndCharacterOfPosition(
+      diagnostic.start
+    );
+    return {
+      character: character + 1,
+      line: line + 1,
+      message: diagnostic.messageText,
+    };
+  });
+
+  expect(normalizedDiagnostics).toMatchObject([
     {
-      messageText:
+      message:
         "Argument of type 'string' is not assignable to parameter of type 'boolean'.",
-      start: 295,
+      line: 10,
+      character: 27,
     },
   ]);
 });
@@ -17,16 +29,29 @@ test("expectAssignable", () => {
 test("expectNotAssignable", () => {
   const { diagnostics } = tsd(fixturePath("expectNotAssignable"));
 
-  expect(diagnostics).toMatchObject([
+  const normalizedDiagnostics = diagnostics.map((diagnostic) => {
+    const { character, line } = diagnostic.file.getLineAndCharacterOfPosition(
+      diagnostic.start
+    );
+    return {
+      character: character + 1,
+      line: line + 1,
+      message: diagnostic.messageText,
+    };
+  });
+
+  expect(normalizedDiagnostics).toMatchObject([
     {
-      messageText:
+      message:
         "Argument of type 'string' is assignable to parameter of type 'string | number'.",
-      start: 128,
+      line: 6,
+      character: 1,
     },
     {
-      messageText:
+      message:
         "Argument of type 'string' is assignable to parameter of type 'any'.",
-      start: 188,
+      line: 7,
+      character: 1,
     },
   ]);
 });

--- a/tests/assignable.test.ts
+++ b/tests/assignable.test.ts
@@ -7,10 +7,9 @@ test("expectAssignable", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Argument of type 'string' is not assignable to parameter of type 'boolean'.",
-      line: 10,
-      column: 27,
+      start: 295,
     },
   ]);
 });
@@ -20,16 +19,14 @@ test("expectNotAssignable", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Argument of type 'string' is assignable to parameter of type 'string | number'.",
-      line: 6,
-      column: 1,
+      start: 128,
     },
     {
-      message:
+      messageText:
         "Argument of type 'string' is assignable to parameter of type 'any'.",
-      line: 7,
-      column: 1,
+      start: 188,
     },
   ]);
 });

--- a/tests/deprecated.test.ts
+++ b/tests/deprecated.test.ts
@@ -7,25 +7,21 @@ test("expectDeprecated", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Expected '(foo: number, bar: number): number' to be marked deprecated",
-      line: 6,
-      column: 1,
+      start: 141,
     },
     {
-      message: "Expected 'Options.delimiter' to be marked deprecated",
-      line: 15,
-      column: 1,
+      messageText: "Expected 'Options.delimiter' to be marked deprecated",
+      start: 292,
     },
     {
-      message: "Expected 'Unicorn.RAINBOW' to be marked deprecated",
-      line: 19,
-      column: 1,
+      messageText: "Expected 'Unicorn.RAINBOW' to be marked deprecated",
+      start: 373,
     },
     {
-      message: "Expected 'RainbowClass' to be marked deprecated",
-      line: 34,
-      column: 1,
+      messageText: "Expected 'RainbowClass' to be marked deprecated",
+      start: 569,
     },
   ]);
 });
@@ -35,25 +31,21 @@ test("expectNotDeprecated", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Expected '(foo: string, bar: string): string' to not be marked deprecated",
-      line: 5,
-      column: 1,
+      start: 104,
     },
     {
-      message: "Expected 'Options.separator' to not be marked deprecated",
-      line: 14,
-      column: 1,
+      messageText: "Expected 'Options.separator' to not be marked deprecated",
+      start: 264,
     },
     {
-      message: "Expected 'Unicorn.UNICORN' to not be marked deprecated",
-      line: 18,
-      column: 1,
+      messageText: "Expected 'Unicorn.UNICORN' to not be marked deprecated",
+      start: 353,
     },
     {
-      message: "Expected 'UnicornClass' to not be marked deprecated",
-      line: 33,
-      column: 1,
+      messageText: "Expected 'UnicornClass' to not be marked deprecated",
+      start: 558,
     },
   ]);
 });

--- a/tests/deprecated.test.ts
+++ b/tests/deprecated.test.ts
@@ -1,27 +1,31 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath } from "./utils";
+import { fixturePath, normalizeDiagnostics } from "./utils";
 
 test("expectDeprecated", () => {
   const { diagnostics } = tsd(fixturePath("expectDeprecated"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText:
+      message:
         "Expected '(foo: number, bar: number): number' to be marked deprecated",
-      start: 141,
+      line: 6,
+      character: 1,
     },
     {
-      messageText: "Expected 'Options.delimiter' to be marked deprecated",
-      start: 292,
+      message: "Expected 'Options.delimiter' to be marked deprecated",
+      line: 15,
+      character: 1,
     },
     {
-      messageText: "Expected 'Unicorn.RAINBOW' to be marked deprecated",
-      start: 373,
+      message: "Expected 'Unicorn.RAINBOW' to be marked deprecated",
+      line: 19,
+      character: 1,
     },
     {
-      messageText: "Expected 'RainbowClass' to be marked deprecated",
-      start: 569,
+      message: "Expected 'RainbowClass' to be marked deprecated",
+      line: 34,
+      character: 1,
     },
   ]);
 });
@@ -29,23 +33,27 @@ test("expectDeprecated", () => {
 test("expectNotDeprecated", () => {
   const { diagnostics } = tsd(fixturePath("expectNotDeprecated"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText:
+      message:
         "Expected '(foo: string, bar: string): string' to not be marked deprecated",
-      start: 104,
+      line: 5,
+      character: 1,
     },
     {
-      messageText: "Expected 'Options.separator' to not be marked deprecated",
-      start: 264,
+      message: "Expected 'Options.separator' to not be marked deprecated",
+      line: 14,
+      character: 1,
     },
     {
-      messageText: "Expected 'Unicorn.UNICORN' to not be marked deprecated",
-      start: 353,
+      message: "Expected 'Unicorn.UNICORN' to not be marked deprecated",
+      line: 18,
+      character: 1,
     },
     {
-      messageText: "Expected 'UnicornClass' to not be marked deprecated",
-      start: 558,
+      message: "Expected 'UnicornClass' to not be marked deprecated",
+      line: 33,
+      character: 1,
     },
   ]);
 });

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,18 +1,20 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath } from "./utils";
+import { fixturePath, normalizeDiagnostics } from "./utils";
 
 test("expectError", () => {
   const { diagnostics } = tsd(fixturePath("expectError"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText: "Expected an error, but found none.",
-      start: 332,
+      message: "Expected an error, but found none.",
+      line: 18,
+      character: 1,
     },
     {
-      messageText: "Expected an error, but found none.",
-      start: 1518,
+      message: "Expected an error, but found none.",
+      line: 89,
+      character: 1,
     },
   ]);
 });

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -7,14 +7,12 @@ test("expectError", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      line: 18,
-      column: 1,
-      message: "Expected an error, but found none.",
+      messageText: "Expected an error, but found none.",
+      start: 332,
     },
     {
-      line: 89,
-      column: 1,
-      message: "Expected an error, but found none.",
+      messageText: "Expected an error, but found none.",
+      start: 1518,
     },
   ]);
 });

--- a/tests/identical.test.ts
+++ b/tests/identical.test.ts
@@ -1,35 +1,40 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath } from "./utils";
+import { fixturePath, normalizeDiagnostics } from "./utils";
 
 test("expectType", () => {
   const { diagnostics } = tsd(fixturePath("expectType"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText:
+      message:
         "Parameter type 'any' is not identical to argument type 'number'.",
-      start: 196,
+      line: 9,
+      character: 1,
     },
     {
-      messageText:
+      message:
         "Parameter type 'string | number' is declared too wide for argument type 'string'.",
-      start: 227,
+      line: 10,
+      character: 1,
     },
     {
-      messageText:
+      message:
         "Parameter type 'false' is not identical to argument type 'any'.",
-      start: 287,
+      line: 12,
+      character: 1,
     },
     {
-      messageText:
+      message:
         "Parameter type 'string' is declared too wide for argument type 'never'.",
-      start: 328,
+      line: 14,
+      character: 1,
     },
     {
-      messageText:
+      message:
         "Parameter type 'any' is declared too wide for argument type 'never'.",
-      start: 361,
+      line: 15,
+      character: 1,
     },
   ]);
 });
@@ -37,15 +42,17 @@ test("expectType", () => {
 test("expectNotType", () => {
   const { diagnostics } = tsd(fixturePath("expectNotType"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText:
+      message:
         "Parameter type 'string' is identical to argument type 'string'.",
-      start: 222,
+      line: 9,
+      character: 1,
     },
     {
-      messageText: "Parameter type 'any' is identical to argument type 'any'.",
-      start: 327,
+      message: "Parameter type 'any' is identical to argument type 'any'.",
+      line: 12,
+      character: 1,
     },
   ]);
 });

--- a/tests/identical.test.ts
+++ b/tests/identical.test.ts
@@ -7,34 +7,29 @@ test("expectType", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Parameter type 'any' is not identical to argument type 'number'.",
-      line: 9,
-      column: 1,
+      start: 196,
     },
     {
-      message:
+      messageText:
         "Parameter type 'string | number' is declared too wide for argument type 'string'.",
-      line: 10,
-      column: 1,
+      start: 227,
     },
     {
-      message:
+      messageText:
         "Parameter type 'false' is not identical to argument type 'any'.",
-      line: 12,
-      column: 1,
+      start: 287,
     },
     {
-      message:
+      messageText:
         "Parameter type 'string' is declared too wide for argument type 'never'.",
-      line: 14,
-      column: 1,
+      start: 328,
     },
     {
-      message:
+      messageText:
         "Parameter type 'any' is declared too wide for argument type 'never'.",
-      line: 15,
-      column: 1,
+      start: 361,
     },
   ]);
 });
@@ -44,15 +39,13 @@ test("expectNotType", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message:
+      messageText:
         "Parameter type 'string' is identical to argument type 'string'.",
-      line: 9,
-      column: 1,
+      start: 222,
     },
     {
-      message: "Parameter type 'any' is identical to argument type 'any'.",
-      line: 12,
-      column: 1,
+      messageText: "Parameter type 'any' is identical to argument type 'any'.",
+      start: 327,
     },
   ]);
 });

--- a/tests/syntax-errors.test.ts
+++ b/tests/syntax-errors.test.ts
@@ -7,24 +7,20 @@ test("syntax errors", () => {
 
   expect(diagnostics).toMatchObject([
     {
-      message: "')' expected.",
-      line: 4,
-      column: 30,
+      messageText: "')' expected.",
+      start: 87,
     },
     {
-      message: "',' expected.",
-      line: 5,
-      column: 23,
+      messageText: "',' expected.",
+      start: 111,
     },
     {
-      line: 4,
-      column: 1,
-      message: "Expected an error, but found none.",
+      messageText: "Expected an error, but found none.",
+      start: 58,
     },
     {
-      line: 5,
-      column: 1,
-      message: "Expected an error, but found none.",
+      messageText: "Expected an error, but found none.",
+      start: 89,
     },
   ]);
 });

--- a/tests/syntax-errors.test.ts
+++ b/tests/syntax-errors.test.ts
@@ -1,26 +1,30 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath } from "./utils";
+import { fixturePath, normalizeDiagnostics } from "./utils";
 
 test("syntax errors", () => {
   const { diagnostics } = tsd(fixturePath("syntax-errors"));
 
-  expect(diagnostics).toMatchObject([
+  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
     {
-      messageText: "')' expected.",
-      start: 87,
+      message: "')' expected.",
+      line: 4,
+      character: 30,
     },
     {
-      messageText: "',' expected.",
-      start: 111,
+      message: "',' expected.",
+      line: 5,
+      character: 23,
     },
     {
-      messageText: "Expected an error, but found none.",
-      start: 58,
+      message: "Expected an error, but found none.",
+      line: 4,
+      character: 1,
     },
     {
-      messageText: "Expected an error, but found none.",
-      start: 89,
+      message: "Expected an error, but found none.",
+      line: 5,
+      character: 1,
     },
   ]);
 });

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "strict": true,
     "noImplicitOverride": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "newLine": "lf"
   },
   "include": ["**/*"]
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -5,8 +5,7 @@
     "moduleResolution": "node",
     "strict": true,
     "noImplicitOverride": true,
-    "skipLibCheck": true,
-    "newLine": "lf"
+    "skipLibCheck": true
   },
   "include": ["**/*"]
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,25 @@
 import { resolve } from "path";
+import type * as ts from "@tsd/typescript";
+import type { Diagnostic } from "../source/types";
 
 export const fixturePath = (fixture: string): string =>
   resolve("tests", fixture, "index.test.ts");
+
+export function normalizeDiagnostics(diagnostics: Diagnostic[]): {
+  file: ts.SourceFile;
+  message: string | ts.DiagnosticMessageChain;
+  character: number;
+  line: number;
+}[] {
+  return diagnostics.map((diagnostic) => {
+    const { character, line } = diagnostic.file.getLineAndCharacterOfPosition(
+      diagnostic.start
+    );
+    return {
+      file: diagnostic.file,
+      message: diagnostic.messageText,
+      line: line + 1,
+      character: character + 1,
+    };
+  });
+}


### PR DESCRIPTION
Return diagnostics in ts-style. Less logic duplication in this library and more flexibility for the end user.