### PR TITLE
refactor!: return `tsdResult` instead of `diagnostics`

### DIFF
--- a/source/handleAssertions/assignable.ts
+++ b/source/handleAssertions/assignable.ts
@@ -1,15 +1,15 @@
 import type * as ts from "@tsd/typescript";
-import { makeDiagnostic } from "./makeDiagnostic";
-import type { Diagnostic } from "../types";
+import { makeTsdResult } from "./makeTsdResult";
+import type { TsdResult } from "../types";
 
 export function expectNotAssignable(
   checker: ts.TypeChecker,
   nodes: Set<ts.CallExpression>
-): Diagnostic[] {
-  const diagnostics: Diagnostic[] = [];
+): TsdResult[] {
+  const tsdResults: TsdResult[] = [];
 
   if (!nodes) {
-    return diagnostics;
+    return tsdResults;
   }
 
   for (const node of nodes) {
@@ -21,8 +21,8 @@ export function expectNotAssignable(
     const argumentType = checker.getTypeAtLocation(node.arguments[0]);
 
     if (checker.isTypeAssignableTo(argumentType, expectedType)) {
-      diagnostics.push(
-        makeDiagnostic(
+      tsdResults.push(
+        makeTsdResult(
           node,
           `Argument of type '${checker.typeToString(
             argumentType
@@ -34,5 +34,5 @@ export function expectNotAssignable(
     }
   }
 
-  return diagnostics;
+  return tsdResults;
 }

--- a/source/handleAssertions/deprecated.ts
+++ b/source/handleAssertions/deprecated.ts
@@ -1,6 +1,6 @@
 import * as ts from "@tsd/typescript";
-import { makeDiagnostic } from "./makeDiagnostic";
-import type { Diagnostic, Handler } from "../types";
+import { makeTsdResult } from "./makeTsdResult";
+import type { Handler, TsdResult } from "../types";
 
 export function expressionToString(
   checker: ts.TypeChecker,
@@ -49,10 +49,10 @@ type Options = {
 
 function expectDeprecatedHelper(options: Options): Handler {
   return (checker, nodes) => {
-    const diagnostics: Diagnostic[] = [];
+    const tsdResults: TsdResult[] = [];
 
     if (!nodes) {
-      return diagnostics;
+      return tsdResults;
     }
 
     for (const node of nodes) {
@@ -66,10 +66,10 @@ function expectDeprecatedHelper(options: Options): Handler {
 
       const message = expressionToString(checker, argument);
 
-      diagnostics.push(makeDiagnostic(node, options.message(message ?? "?")));
+      tsdResults.push(makeTsdResult(node, options.message(message ?? "?")));
     }
 
-    return diagnostics;
+    return tsdResults;
   };
 }
 

--- a/source/handleAssertions/identical.ts
+++ b/source/handleAssertions/identical.ts
@@ -1,15 +1,15 @@
 import type * as ts from "@tsd/typescript";
-import { makeDiagnostic } from "./makeDiagnostic";
-import type { Diagnostic } from "../types";
+import { makeTsdResult } from "./makeTsdResult";
+import type { TsdResult } from "../types";
 
 export function expectType(
   checker: ts.TypeChecker,
   nodes: Set<ts.CallExpression>
-): Diagnostic[] {
-  const diagnostics: Diagnostic[] = [];
+): TsdResult[] {
+  const tsdResults: TsdResult[] = [];
 
   if (!nodes) {
-    return diagnostics;
+    return tsdResults;
   }
 
   for (const node of nodes) {
@@ -26,8 +26,8 @@ export function expectType(
     }
 
     if (!checker.isTypeAssignableTo(expectedType, argumentType)) {
-      diagnostics.push(
-        makeDiagnostic(
+      tsdResults.push(
+        makeTsdResult(
           node,
           `Parameter type '${checker.typeToString(
             expectedType
@@ -41,8 +41,8 @@ export function expectType(
        * The expected type and argument type are assignable in both directions. We still have to check
        * if the types are identical. See https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#3.11.2.
        */
-      diagnostics.push(
-        makeDiagnostic(
+      tsdResults.push(
+        makeTsdResult(
           node,
           `Parameter type '${checker.typeToString(
             expectedType
@@ -54,17 +54,17 @@ export function expectType(
     }
   }
 
-  return diagnostics;
+  return tsdResults;
 }
 
 export function expectNotType(
   checker: ts.TypeChecker,
   nodes: Set<ts.CallExpression>
-): Diagnostic[] {
-  const diagnostics: Diagnostic[] = [];
+): TsdResult[] {
+  const tsdResults: TsdResult[] = [];
 
   if (!nodes) {
-    return diagnostics;
+    return tsdResults;
   }
 
   for (const node of nodes) {
@@ -76,8 +76,8 @@ export function expectNotType(
     const argumentType = checker.getTypeAtLocation(node.arguments[0]);
 
     if (checker.isTypeIdenticalTo(expectedType, argumentType)) {
-      diagnostics.push(
-        makeDiagnostic(
+      tsdResults.push(
+        makeTsdResult(
           node,
           `Parameter type '${checker.typeToString(
             expectedType
@@ -89,5 +89,5 @@ export function expectNotType(
     }
   }
 
-  return diagnostics;
+  return tsdResults;
 }

--- a/source/handleAssertions/index.ts
+++ b/source/handleAssertions/index.ts
@@ -1,5 +1,5 @@
 import type * as ts from "@tsd/typescript";
-import type { Diagnostic, Handler } from "../types";
+import type { Handler, TsdResult } from "../types";
 import { expectNotAssignable } from "./assignable";
 import { expectDeprecated, expectNotDeprecated } from "./deprecated";
 import { expectType, expectNotType } from "./identical";
@@ -25,8 +25,8 @@ const assertionHandlers = new Map<Assertion, Handler>([
 export function handleAssertions(
   typeChecker: ts.TypeChecker,
   assertions: Map<Assertion, Set<ts.CallExpression>>
-): Diagnostic[] {
-  const diagnostics: Diagnostic[] = [];
+): TsdResult[] {
+  const tadResults: TsdResult[] = [];
 
   for (const [assertion, nodes] of assertions) {
     const handler = assertionHandlers.get(assertion);
@@ -35,8 +35,8 @@ export function handleAssertions(
       continue;
     }
 
-    diagnostics.push(...handler(typeChecker, nodes));
+    tadResults.push(...handler(typeChecker, nodes));
   }
 
-  return diagnostics;
+  return tadResults;
 }

--- a/source/handleAssertions/makeTsdResult.ts
+++ b/source/handleAssertions/makeTsdResult.ts
@@ -1,7 +1,7 @@
 import type * as ts from "@tsd/typescript";
-import type { Diagnostic } from "../types";
+import type { TsdResult } from "../types";
 
-export function makeDiagnostic(node: ts.Node, messageText: string): Diagnostic {
+export function makeTsdResult(node: ts.Node, messageText: string): TsdResult {
   return {
     file: node.getSourceFile(),
     start: node.getStart(),

--- a/source/index.ts
+++ b/source/index.ts
@@ -9,3 +9,5 @@ export {
   expectNotType,
   expectType,
 } from "./assertions";
+
+export type { TsdResult } from "./types";

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,12 +1,12 @@
 import type * as ts from "@tsd/typescript";
 
-export type Diagnostic = {
+export type TsdResult = {
   file: ts.SourceFile;
   messageText: string | ts.DiagnosticMessageChain;
   start: number;
 };
 
-export type ExpectedError = Omit<Diagnostic, "messageText">;
+export type ExpectedError = Omit<TsdResult, "messageText">;
 
 export type Location = {
   fileName: string;
@@ -17,4 +17,4 @@ export type Location = {
 export type Handler = (
   typeChecker: ts.TypeChecker,
   nodes: Set<ts.CallExpression>
-) => Diagnostic[];
+) => TsdResult[];

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,18 +1,18 @@
 import { normalize, resolve } from "path";
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostics } from "./utils";
+import { fixturePath, normalizeResults } from "./utils";
 
 test("returns `ts.SourceFile` object", () => {
-  const { diagnostics } = tsd(fixturePath("failing"));
+  const { tsdResults } = tsd(fixturePath("failing"));
 
-  expect(diagnostics).toHaveLength(2);
-  expect(normalize(diagnostics[0].file.fileName)).toEqual(
+  expect(tsdResults).toHaveLength(2);
+  expect(normalize(tsdResults[0].file.fileName)).toEqual(
     resolve("tests", "failing", "index.test.ts")
   );
 
-  expect(diagnostics[0].file.text).toEqual(diagnostics[1].file.text);
-  expect(diagnostics[0].file.text).toMatchInlineSnapshot(`
+  expect(tsdResults[0].file.text).toEqual(tsdResults[1].file.text);
+  expect(tsdResults[0].file.text).toMatchInlineSnapshot(`
     "import { expectError, expectType } from \\"../../\\";
     import { makeDate } from \\".\\";
 
@@ -32,15 +32,15 @@ test("returns `assertionCount`", () => {
 });
 
 test("passing", () => {
-  const { diagnostics } = tsd(fixturePath("passing"));
+  const { tsdResults } = tsd(fixturePath("passing"));
 
-  expect(diagnostics).toHaveLength(0);
+  expect(tsdResults).toHaveLength(0);
 });
 
 test("failing", () => {
-  const { diagnostics } = tsd(fixturePath("failing"));
+  const { tsdResults } = tsd(fixturePath("failing"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Argument of type 'Date' is not assignable to parameter of type 'string'.",
@@ -56,9 +56,9 @@ test("failing", () => {
 });
 
 test("failing-nested", () => {
-  const { diagnostics } = tsd(fixturePath("failing-nested"));
+  const { tsdResults } = tsd(fixturePath("failing-nested"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       file: {
         fileName: expect.stringContaining("index.test.ts"),

--- a/tests/assignable.test.ts
+++ b/tests/assignable.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostics } from "./utils";
+import { fixturePath, normalizeResults } from "./utils";
 
 test("expectAssignable", () => {
-  const { diagnostics } = tsd(fixturePath("expectAssignable"));
+  const { tsdResults } = tsd(fixturePath("expectAssignable"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Argument of type 'string' is not assignable to parameter of type 'boolean'.",
@@ -16,9 +16,9 @@ test("expectAssignable", () => {
 });
 
 test("expectNotAssignable", () => {
-  const { diagnostics } = tsd(fixturePath("expectNotAssignable"));
+  const { tsdResults } = tsd(fixturePath("expectNotAssignable"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Argument of type 'string' is assignable to parameter of type 'string | number'.",

--- a/tests/compilerOptions.test.ts
+++ b/tests/compilerOptions.test.ts
@@ -3,13 +3,13 @@ import tsd from "../";
 import { fixturePath } from "./utils";
 
 test("`compilerOptions.lib` in nearest `tsconfig.json`", () => {
-  const { diagnostics } = tsd(fixturePath("compilerOptions-lib"));
+  const { tsdResults } = tsd(fixturePath("compilerOptions-lib"));
 
-  expect(diagnostics).toHaveLength(0);
+  expect(tsdResults).toHaveLength(0);
 });
 
 test("`compilerOptions.strict` in nearest `tsconfig.json`", () => {
-  const { diagnostics } = tsd(fixturePath("compilerOptions-strict"));
+  const { tsdResults } = tsd(fixturePath("compilerOptions-strict"));
 
-  expect(diagnostics).toHaveLength(0);
+  expect(tsdResults).toHaveLength(0);
 });

--- a/tests/deprecated.test.ts
+++ b/tests/deprecated.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostics } from "./utils";
+import { fixturePath, normalizeResults } from "./utils";
 
 test("expectDeprecated", () => {
-  const { diagnostics } = tsd(fixturePath("expectDeprecated"));
+  const { tsdResults } = tsd(fixturePath("expectDeprecated"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Expected '(foo: number, bar: number): number' to be marked deprecated",
@@ -31,9 +31,9 @@ test("expectDeprecated", () => {
 });
 
 test("expectNotDeprecated", () => {
-  const { diagnostics } = tsd(fixturePath("expectNotDeprecated"));
+  const { tsdResults } = tsd(fixturePath("expectNotDeprecated"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Expected '(foo: string, bar: string): string' to not be marked deprecated",

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostics } from "./utils";
+import { fixturePath, normalizeResults } from "./utils";
 
 test("expectError", () => {
-  const { diagnostics } = tsd(fixturePath("expectError"));
+  const { tsdResults } = tsd(fixturePath("expectError"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message: "Expected an error, but found none.",
       line: 18,

--- a/tests/identical.test.ts
+++ b/tests/identical.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostics } from "./utils";
+import { fixturePath, normalizeResults } from "./utils";
 
 test("expectType", () => {
-  const { diagnostics } = tsd(fixturePath("expectType"));
+  const { tsdResults } = tsd(fixturePath("expectType"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Parameter type 'any' is not identical to argument type 'number'.",
@@ -40,9 +40,9 @@ test("expectType", () => {
 });
 
 test("expectNotType", () => {
-  const { diagnostics } = tsd(fixturePath("expectNotType"));
+  const { tsdResults } = tsd(fixturePath("expectNotType"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
         "Parameter type 'string' is identical to argument type 'string'.",

--- a/tests/promises.test.ts
+++ b/tests/promises.test.ts
@@ -3,7 +3,7 @@ import tsd from "../";
 import { fixturePath } from "./utils";
 
 test("promises", () => {
-  const { diagnostics } = tsd(fixturePath("promises"));
+  const { tsdResults } = tsd(fixturePath("promises"));
 
-  expect(diagnostics).toHaveLength(0);
+  expect(tsdResults).toHaveLength(0);
 });

--- a/tests/syntax-errors.test.ts
+++ b/tests/syntax-errors.test.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostics } from "./utils";
+import { fixturePath, normalizeResults } from "./utils";
 
 test("syntax errors", () => {
-  const { diagnostics } = tsd(fixturePath("syntax-errors"));
+  const { tsdResults } = tsd(fixturePath("syntax-errors"));
 
-  expect(normalizeDiagnostics(diagnostics)).toMatchObject([
+  expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message: "')' expected.",
       line: 4,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,23 +1,23 @@
 import { resolve } from "path";
 import type * as ts from "@tsd/typescript";
-import type { Diagnostic } from "../source/types";
+import type { TsdResult } from "../";
 
 export const fixturePath = (fixture: string): string =>
   resolve("tests", fixture, "index.test.ts");
 
-export function normalizeDiagnostics(diagnostics: Diagnostic[]): {
+export function normalizeResults(results: TsdResult[]): {
   file: ts.SourceFile;
   message: string | ts.DiagnosticMessageChain;
-  character: number;
   line: number;
+  character: number;
 }[] {
-  return diagnostics.map((diagnostic) => {
-    const { character, line } = diagnostic.file.getLineAndCharacterOfPosition(
-      diagnostic.start
+  return results.map((result) => {
+    const { character, line } = result.file.getLineAndCharacterOfPosition(
+      result.start
     );
     return {
-      file: diagnostic.file,
-      message: diagnostic.messageText,
+      file: result.file,
+      message: result.messageText,
       line: line + 1,
       character: character + 1,
     };


### PR DESCRIPTION
Returning `tsdResult` makes it more clear that this is the result. Less overlap with diagnostics of TypeScript compiler.