### PR TITLE
refactor!: fail early if syntax errors are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ While `tsd` suites perfectly for JavaScript libraries which declare their types 
 - Comes with no default compiler options.
 - Reads TypeScript compiler options from the nearest `tsconfig.json` for each test file (does not read options from `package.json`).
 - `tsd-lite` is optionally `strict`. You should add `"strict": true` to the nearest `tsconfig.json` (it can be project or test specific) to use strict assertions.
+- `tsdErrors` object is returned if `tsd-lite` encounters errors while parsing `tsconfig.json` or if syntax errors are found in the test files.
 - [`@tsd/typescript`](https://npmjs.com/package/@tsd/typescript) package is moved to peer dependencies.
 - `tsd-lite` allows only programmatic [usage](#usage).
 
@@ -36,7 +37,7 @@ This library is intended for programmatic use only.
 ```ts
 import tsdLite from "tsd-lite";
 
-const { assertionCount, tsdResults } = tsdLite(
+const { assertionCount, tsdErrors, tsdResults } = tsdLite(
   "/absolute/path/to/testFile.test.ts"
 );
 ```
@@ -54,9 +55,9 @@ tsdResults: Array<{
   messageText: string | ts.DiagnosticMessageChain;
   start: number;
 }>;
-configDiagnostics?: Array<ts.Diagnostic>;
+tsdErrors?: ReadonlyArray<ts.Diagnostic | ts.DiagnosticWithLocation>;
 ```
 
 ## License
 
-MIT © Sam Verschueren
+[MIT](https://github.com/mrazauskas/tsd-lite/blob/main/LICENSE.md)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,5 +1,5 @@
 {
   "language": "en-US",
   "files": ["source/**/*", "tests/**/*", "*.md"],
-  "words": ["nodenext", "Verschueren"]
+  "words": ["Verschueren"]
 }

--- a/tests/compilerOptions.test.ts
+++ b/tests/compilerOptions.test.ts
@@ -1,40 +1,35 @@
 import { join, normalize } from "path";
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeDiagnostic } from "./utils";
+import { fixturePath, normalizeErrors } from "./utils";
 
 test("`compilerOptions.lib` in nearest `tsconfig.json`", () => {
-  const { configDiagnostics, tsdResults } = tsd(
-    fixturePath("compilerOptions-lib")
-  );
+  const { tsdErrors, tsdResults } = tsd(fixturePath("compilerOptions-lib"));
 
-  expect(configDiagnostics).toBeUndefined();
+  expect(tsdErrors).toBeUndefined();
   expect(tsdResults).toHaveLength(0);
 });
 
 test("`compilerOptions.strict` in nearest `tsconfig.json`", () => {
-  const { configDiagnostics, tsdResults } = tsd(
-    fixturePath("compilerOptions-strict")
-  );
+  const { tsdErrors, tsdResults } = tsd(fixturePath("compilerOptions-strict"));
 
-  expect(configDiagnostics).toBeUndefined();
+  expect(tsdErrors).toBeUndefined();
   expect(tsdResults).toHaveLength(0);
 });
 
 test("when parsing `tsconfig.json` returns errors", () => {
-  const { assertionCount, configDiagnostics, tsdResults } = tsd(
+  const { assertionCount, tsdErrors, tsdResults } = tsd(
     fixturePath("compilerOptions-errors")
   );
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  expect(normalize(configDiagnostics![0].file!.fileName)).toEqual(
+  expect(normalize(tsdErrors![0].file!.fileName)).toEqual(
     join(__dirname, "compilerOptions-errors", "tsconfig.json")
   );
 
-  expect(normalizeDiagnostic(configDiagnostics)).toMatchObject([
+  expect(normalizeErrors(tsdErrors)).toMatchObject([
     {
-      message:
-        "Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node12', 'nodenext'.",
+      message: expect.stringContaining("Argument for '--module' option must"),
       line: 3,
       character: 15,
     },
@@ -44,10 +39,8 @@ test("when parsing `tsconfig.json` returns errors", () => {
       character: 15,
     },
     {
-      file: undefined,
       message: expect.stringContaining("No inputs were found in config file"),
-      line: undefined,
-      character: undefined,
+      file: undefined,
     },
   ]);
 

--- a/tests/syntax-errors.test.ts
+++ b/tests/syntax-errors.test.ts
@@ -1,11 +1,13 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeResults } from "./utils";
+import { fixturePath, normalizeErrors } from "./utils";
 
 test("syntax errors", () => {
-  const { tsdResults } = tsd(fixturePath("syntax-errors"));
+  const { tsdErrors, tsdResults } = tsd(fixturePath("syntax-errors"));
 
-  expect(normalizeResults(tsdResults)).toMatchObject([
+  expect(tsdResults).toHaveLength(0);
+
+  expect(normalizeErrors(tsdErrors)).toMatchObject([
     {
       message: "')' expected.",
       line: 4,
@@ -15,16 +17,6 @@ test("syntax errors", () => {
       message: "',' expected.",
       line: 5,
       character: 23,
-    },
-    {
-      message: "Expected an error, but found none.",
-      line: 4,
-      character: 1,
-    },
-    {
-      message: "Expected an error, but found none.",
-      line: 5,
-      character: 1,
     },
   ]);
 });


### PR DESCRIPTION
If a test file has syntax errors, the tsd result might be unpredictable. Better to fail early.