### PR TITLE
feat!: throw instead of returning tsdErrors

### DIFF
--- a/.yarn/versions/b0a95d05.yml
+++ b/.yarn/versions/b0a95d05.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file.
+
+### ⚠ BREAKING CHANGES
+
+- throw error (instead of returning `tsdErrors`) if: TS compiler encountered an error while parsing `tsconfig.json`; or found a syntax error while compiling the code.
 
 ## [0.3.0](https://github.com/mrazauskas/tsd-lite/compare/v0.2.0...v0.3.0) (2022-01-14)
 

--- a/README.md
+++ b/README.md
@@ -54,17 +54,13 @@ The exported function takes fully resolved path to a test file as an argument an
   tsdResults: Array<{
     message: string;
     messageText: string | ts.DiagnosticMessageChain;
-    file: ts.SourceFile | undefined;
-    start: number | undefined;
-  }>;
-  tsdErrors?: Array<{
-    message: string;
-    messageText: string | ts.DiagnosticMessageChain;
-    file: ts.SourceFile | undefined;
-    start: number | undefined;
+    file?: ts.SourceFile;
+    start?: number;
   }>;
 };
 ```
+
+`tsd-lite` will throw if TS compiler encountered an error while parsing `tsconfig.json` or found a syntax error while compiling the code.
 
 ## License
 

--- a/source/utils/TsdError.ts
+++ b/source/utils/TsdError.ts
@@ -1,0 +1,33 @@
+import * as ts from "@tsd/typescript";
+import { isDiagnosticWithLocation } from "./isDiagnosticWithLocation";
+
+function formatMassageAndLocation(diagnostic: ts.Diagnostic): {
+  message: string;
+  location?: string;
+} {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+
+  if (isDiagnosticWithLocation(diagnostic)) {
+    const { file, start } = diagnostic;
+
+    const { line, character } = file.getLineAndCharacterOfPosition(start);
+    const location = `at ${file.fileName}:${line + 1}:${character + 1}`;
+
+    return { message, location };
+  }
+
+  return { message };
+}
+
+export class TsdError extends Error {
+  constructor(diagnostic: ts.Diagnostic, name: string) {
+    const { message, location } = formatMassageAndLocation(diagnostic);
+
+    super(message);
+
+    this.name = name;
+    this.stack = [`${this.name}: ${this.message}`, location]
+      .filter((line) => line !== undefined)
+      .join("\n    ");
+  }
+}

--- a/source/utils/index.ts
+++ b/source/utils/index.ts
@@ -1,0 +1,3 @@
+export { TsdError } from "./TsdError";
+export { isDiagnosticWithLocation } from "./isDiagnosticWithLocation";
+export { resolveCompilerOptions } from "./resolveCompilerOptions";

--- a/source/utils/isDiagnosticWithLocation.ts
+++ b/source/utils/isDiagnosticWithLocation.ts
@@ -1,0 +1,5 @@
+import type * as ts from "@tsd/typescript";
+
+export const isDiagnosticWithLocation = (
+  diagnostic: ts.Diagnostic
+): diagnostic is ts.DiagnosticWithLocation => diagnostic.file !== undefined;

--- a/source/utils/resolveCompilerOptions.ts
+++ b/source/utils/resolveCompilerOptions.ts
@@ -1,10 +1,8 @@
 import { dirname } from "path";
 import * as ts from "@tsd/typescript";
+import { TsdError } from "./TsdError";
 
-export function resolveCompilerOptions(searchPath: string): {
-  compilerOptions: ts.CompilerOptions;
-  configDiagnostics: Array<ts.Diagnostic>;
-} {
+export function resolveCompilerOptions(searchPath: string): ts.CompilerOptions {
   const configPath = ts.findConfigFile(searchPath, ts.sys.fileExists);
 
   if (configPath === undefined) {
@@ -22,5 +20,9 @@ export function resolveCompilerOptions(searchPath: string): {
       configPath
     );
 
-  return { compilerOptions, configDiagnostics };
+  if (configDiagnostics.length > 0) {
+    throw new TsdError(configDiagnostics[0], "ConfigError");
+  }
+
+  return compilerOptions;
 }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 import { normalize, resolve } from "path";
 import { expect, test } from "@jest/globals";
 import tsd from "../";
@@ -7,12 +9,12 @@ test("returns `ts.SourceFile` object", () => {
   const { tsdResults } = tsd(fixturePath("failing"));
 
   expect(tsdResults).toHaveLength(2);
-  expect(normalize(tsdResults[0].file.fileName)).toEqual(
+  expect(normalize(tsdResults[0].file!.fileName)).toEqual(
     resolve("tests", "failing", "index.test.ts")
   );
 
-  expect(tsdResults[0].file.text).toEqual(tsdResults[1].file.text);
-  expect(tsdResults[0].file.text).toMatchInlineSnapshot(`
+  expect(tsdResults[0].file!.text).toEqual(tsdResults[1].file!.text);
+  expect(tsdResults[0].file!.text).toMatchInlineSnapshot(`
     "import { expectError, expectType } from \\"../../\\";
     import { makeDate } from \\".\\";
 

--- a/tests/compilerOptions-errors/tsconfig.json
+++ b/tests/compilerOptions-errors/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "random",
+    "module": "commonjs",
     "target": "es2019",
     "strict": "yes",
     "noEmitOnError": true

--- a/tests/compilerOptions.test.ts
+++ b/tests/compilerOptions.test.ts
@@ -1,49 +1,21 @@
-import { join, normalize } from "path";
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeErrors } from "./utils";
+import { fixturePath } from "./utils";
 
 test("`compilerOptions.lib` in nearest `tsconfig.json`", () => {
-  const { tsdErrors, tsdResults } = tsd(fixturePath("compilerOptions-lib"));
+  const { tsdResults } = tsd(fixturePath("compilerOptions-lib"));
 
-  expect(tsdErrors).toBeUndefined();
   expect(tsdResults).toHaveLength(0);
 });
 
 test("`compilerOptions.strict` in nearest `tsconfig.json`", () => {
-  const { tsdErrors, tsdResults } = tsd(fixturePath("compilerOptions-strict"));
+  const { tsdResults } = tsd(fixturePath("compilerOptions-strict"));
 
-  expect(tsdErrors).toBeUndefined();
   expect(tsdResults).toHaveLength(0);
 });
 
 test("when parsing `tsconfig.json` returns errors", () => {
-  const { assertionsCount, tsdErrors, tsdResults } = tsd(
-    fixturePath("compilerOptions-errors")
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  expect(normalize(tsdErrors![0].file!.fileName)).toEqual(
-    join(__dirname, "compilerOptions-errors", "tsconfig.json")
-  );
-
-  expect(normalizeErrors(tsdErrors)).toMatchObject([
-    {
-      message: expect.stringMatching(/^Argument for '--module' option must/),
-      line: 3,
-      character: 15,
-    },
-    {
-      message: "Compiler option 'strict' requires a value of type boolean.",
-      line: 5,
-      character: 15,
-    },
-    {
-      message: expect.stringMatching(/^No inputs were found in config file/),
-      file: undefined,
-    },
-  ]);
-
-  expect(assertionsCount).toBe(0);
-  expect(tsdResults).toHaveLength(0);
+  expect(() => {
+    tsd(fixturePath("compilerOptions-errors"));
+  }).toThrow("Compiler option 'strict' requires a value of type boolean.");
 });

--- a/tests/syntax-errors.test.ts
+++ b/tests/syntax-errors.test.ts
@@ -1,22 +1,9 @@
 import { expect, test } from "@jest/globals";
 import tsd from "../";
-import { fixturePath, normalizeErrors } from "./utils";
+import { fixturePath } from "./utils";
 
 test("syntax errors", () => {
-  const { tsdErrors, tsdResults } = tsd(fixturePath("syntax-errors"));
-
-  expect(tsdResults).toHaveLength(0);
-
-  expect(normalizeErrors(tsdErrors)).toMatchObject([
-    {
-      message: "SyntaxError: ')' expected.",
-      line: 4,
-      character: 30,
-    },
-    {
-      message: "SyntaxError: ',' expected.",
-      line: 5,
-      character: 23,
-    },
-  ]);
+  expect(() => {
+    tsd(fixturePath("syntax-errors"));
+  }).toThrow("')' expected.");
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,64 +1,45 @@
 import { join } from "path";
 import type * as ts from "@tsd/typescript";
-import type { AssertionResult, ErrorResult, TsdResult } from "../source/types";
+import type { TsdResult } from "../source/types";
 
 export const fixturePath = (fixture: string): string =>
   join(__dirname, fixture, "index.test.ts");
 
-type NormalizedResult = {
-  message: string;
+type TsdResultWithLocation = TsdResult & {
   file: ts.SourceFile;
-  line: number;
-  character: number;
+  start: number;
 };
 
-export function normalizeResults(
-  results: Array<TsdResult<AssertionResult>>
-): Array<NormalizedResult> {
-  return results.map((result) => {
-    const { line, character } = result.file.getLineAndCharacterOfPosition(
-      result.start
-    );
-    return {
-      message: result.message,
-      file: result.file,
-      line: line + 1,
-      character: character + 1,
-    };
-  });
-}
+const isTsdResultWithLocation = (
+  result: TsdResult
+): result is TsdResultWithLocation => result.file !== undefined;
 
-type NormalizedError = {
+type NormalizedResult = {
   message: string;
   file?: ts.SourceFile;
   line?: number;
   character?: number;
 };
 
-const isDiagnosticWithLocation = (
-  diagnostic: TsdResult<ErrorResult>
-): diagnostic is TsdResult<ts.DiagnosticWithLocation> =>
-  diagnostic.file !== undefined;
-
-export function normalizeErrors(
-  errors: Array<TsdResult<ErrorResult>> = []
-): Array<NormalizedError> {
-  return errors.map((error) => {
-    if (isDiagnosticWithLocation(error)) {
-      const { line, character } = error.file.getLineAndCharacterOfPosition(
-        error.start
+export function normalizeResults(
+  results: Array<TsdResult> = []
+): Array<NormalizedResult> {
+  return results.map((result) => {
+    if (isTsdResultWithLocation(result)) {
+      const { line, character } = result.file.getLineAndCharacterOfPosition(
+        result.start
       );
       return {
-        message: error.message,
-        file: error.file,
+        message: result.message,
+        file: result.file,
         line: line + 1,
         character: character + 1,
       };
     }
 
     return {
-      message: error.message,
-      file: error.file,
+      message: result.message,
+      file: result.file,
     };
   });
 }


### PR DESCRIPTION
Throw `TsdError` (instead of returning `tsdErrors`) if:
- TS compiler encountered an error while parsing `tsconfig.json`;
- or found a syntax error while compiling the code.