### PR TITLE
refactor!: do not add message

### DIFF
--- a/.yarn/versions/a866028a.yml
+++ b/.yarn/versions/a866028a.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚠ BREAKING CHANGES
 
+- do not add flattened `message` to `tsdResults` object. `messageText` is there already and should be used instead.
 - throw error (instead of returning `tsdErrors`) if: TS compiler encountered an error while parsing `tsconfig.json`; or found a syntax error while compiling the code.
 
 ## [0.3.0](https://github.com/mrazauskas/tsd-lite/compare/v0.2.0...v0.3.0) (2022-01-14)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The exported function takes fully resolved path to a test file as an argument an
 {
   assertionsCount: number;
   tsdResults: Array<{
-    message: string;
     messageText: string | ts.DiagnosticMessageChain;
     file?: ts.SourceFile;
     start?: number;

--- a/source/tsdLite.ts
+++ b/source/tsdLite.ts
@@ -15,10 +15,6 @@ import {
 
 function toTsdResult(rawResult: AssertionResult | ts.Diagnostic): TsdResult {
   return {
-    message: ts.flattenDiagnosticMessageText(
-      rawResult.messageText,
-      ts.sys.newLine
-    ),
     messageText: rawResult.messageText,
     file: rawResult.file,
     start: rawResult.start,

--- a/source/types.ts
+++ b/source/types.ts
@@ -6,6 +6,4 @@ export type AssertionResult = {
   start: number | undefined;
 };
 
-export type TsdResult = AssertionResult & {
-  message: string;
-};
+export type TsdResult = AssertionResult;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import type * as ts from "@tsd/typescript";
+import * as ts from "@tsd/typescript";
 import type { TsdResult } from "../source/types";
 
 export const fixturePath = (fixture: string): string =>
@@ -30,7 +30,7 @@ export function normalizeResults(
         result.start
       );
       return {
-        message: result.message,
+        message: ts.flattenDiagnosticMessageText(result.messageText, "\n"),
         file: result.file,
         line: line + 1,
         character: character + 1,
@@ -38,7 +38,7 @@ export function normalizeResults(
     }
 
     return {
-      message: result.message,
+      message: ts.flattenDiagnosticMessageText(result.messageText, "\n"),
       file: result.file,
     };
   });


### PR DESCRIPTION
Do not add flattened `message` to `tsdResults` object. `messageText` is there already and should be used instead.
