### PR TITLE
perf: skip declaration files

### DIFF
--- a/.yarn/versions/11126c96.yml
+++ b/.yarn/versions/11126c96.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 - do not add flattened `message` to `tsdResults` object. `messageText` is there already and should be used instead.
 - throw error (instead of returning `tsdErrors`) if: TS compiler encountered an error while parsing `tsconfig.json`; or found a syntax error while compiling the code.
 
+### Performance
+
+- parser will skip declaration files while extracting assertions.
+
 ## [0.3.0](https://github.com/mrazauskas/tsd-lite/compare/v0.2.0...v0.3.0) (2022-01-14)
 
 ### ⚠ BREAKING CHANGES

--- a/source/parser.ts
+++ b/source/parser.ts
@@ -34,7 +34,9 @@ export function extractAssertions(program: ts.Program): {
   }
 
   for (const sourceFile of program.getSourceFiles()) {
-    visit(sourceFile);
+    if (!sourceFile.isDeclarationFile) {
+      visit(sourceFile);
+    }
   }
 
   let assertionsCount = 0;


### PR DESCRIPTION
Parser will skip declaration files while extracting assertions. Test files should have all the assertions.