### PR TITLE
fix: resolve compiler options correctly in case tsconfig.json is not found

### DIFF
--- a/.yarn/versions/bac0538f.yml
+++ b/.yarn/versions/bac0538f.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+### Bug Fixes
+
+- resolve compiler options correctly if `tsconfig.json` is not found.
+
 ## [0.4.0](https://github.com/mrazauskas/tsd-lite/compare/v0.3.0...v0.4.0) (2022-01-17)
 
 ### ⚠ BREAKING CHANGES

--- a/source/tsdLite.ts
+++ b/source/tsdLite.ts
@@ -27,7 +27,7 @@ export function tsdLite(testFilePath: string): {
 } {
   const compilerOptions = resolveCompilerOptions(testFilePath);
 
-  const program = ts.createProgram([testFilePath], compilerOptions);
+  const program = ts.createProgram([testFilePath], compilerOptions || {});
   const syntacticDiagnostics = program.getSyntacticDiagnostics();
 
   if (syntacticDiagnostics.length !== 0) {

--- a/source/utils/resolveCompilerOptions.ts
+++ b/source/utils/resolveCompilerOptions.ts
@@ -2,11 +2,13 @@ import { dirname } from "path";
 import * as ts from "@tsd/typescript";
 import { TsdError } from "./TsdError";
 
-export function resolveCompilerOptions(searchPath: string): ts.CompilerOptions {
+export function resolveCompilerOptions(
+  searchPath: string
+): ts.CompilerOptions | undefined {
   const configPath = ts.findConfigFile(searchPath, ts.sys.fileExists);
 
   if (configPath === undefined) {
-    return { compilerOptions: {}, configDiagnostics: [] };
+    return;
   }
 
   const sourceFile = ts.readJsonConfigFile(configPath, ts.sys.readFile);


### PR DESCRIPTION
Fixing regression. Should use default compiler options in case `tsconfig.json` is not found.