### PR TITLE
fix!: improve expectType and expectAssignable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -6,7 +7,14 @@
   ],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "root": true,
+  "overrides": [
+    {
+      "files": ["source/assertions.ts"],
+      "rules": {
+        "@typescript-eslint/no-unused-vars": ["off"]
+      }
+    }
+  ],
   "rules": {
     "@typescript-eslint/array-type": ["error", { "default": "generic" }],
     "@typescript-eslint/explicit-module-boundary-types": "error"

--- a/.yarn/versions/ea0f85d4.yml
+++ b/.yarn/versions/ea0f85d4.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/source/assertions.ts
+++ b/source/assertions.ts
@@ -3,28 +3,28 @@
  *
  * @param value - Value that should be identical to type `T`.
  */
-export declare function expectType<T>(value: T): void;
+export declare function expectType<T>(value: unknown): void;
 
 /**
  * Check that the type of `value` is not identical to type `T`.
  *
  * @param value - Value that should be identical to type `T`.
  */
-export declare function expectNotType<T>(value: unknown): void; // eslint-disable-line @typescript-eslint/no-unused-vars
+export declare function expectNotType<T>(value: unknown): void;
 
 /**
  * Check that the type of `value` is assignable to type `T`.
  *
  * @param value - Value that should be assignable to type `T`.
  */
-export declare function expectAssignable<T>(value: T): void;
+export declare function expectAssignable<T>(value: unknown): void;
 
 /**
  * Check that the type of `value` is not assignable to type `T`.
  *
  * @param value - Value that should not be assignable to type `T`.
  */
-export declare function expectNotAssignable<T>(value: unknown): void; // eslint-disable-line @typescript-eslint/no-unused-vars
+export declare function expectNotAssignable<T>(value: unknown): void;
 
 /**
  * Assert the value to throw an argument error.

--- a/source/handleAssertions/assignable.ts
+++ b/source/handleAssertions/assignable.ts
@@ -36,3 +36,38 @@ export function expectNotAssignable(
 
   return tsdResults;
 }
+
+export function expectAssignable(
+  checker: ts.TypeChecker,
+  nodes: Set<ts.CallExpression>
+): Array<AssertionResult> {
+  const tsdResults: Array<AssertionResult> = [];
+
+  if (!nodes) {
+    return tsdResults;
+  }
+
+  for (const node of nodes) {
+    if (!node.typeArguments) {
+      continue;
+    }
+
+    const expectedType = checker.getTypeFromTypeNode(node.typeArguments[0]);
+    const argumentType = checker.getTypeAtLocation(node.arguments[0]);
+
+    if (!checker.isTypeAssignableTo(argumentType, expectedType)) {
+      tsdResults.push(
+        toAssertionResult(
+          node,
+          `Argument of type '${checker.typeToString(
+            argumentType
+          )}' is not assignable to parameter of type '${checker.typeToString(
+            expectedType
+          )}'.`
+        )
+      );
+    }
+  }
+
+  return tsdResults;
+}

--- a/source/handleAssertions/identical.ts
+++ b/source/handleAssertions/identical.ts
@@ -21,7 +21,16 @@ export function expectType(
     const argumentType = checker.getTypeAtLocation(node.arguments[0]);
 
     if (!checker.isTypeAssignableTo(argumentType, expectedType)) {
-      // The argument type is not assignable to the expected type. TypeScript will catch this for us.
+      tsdResults.push(
+        toAssertionResult(
+          node,
+          `Argument of type '${checker.typeToString(
+            argumentType
+          )}' is not assignable to parameter of type '${checker.typeToString(
+            expectedType
+          )}'.`
+        )
+      );
       continue;
     }
 
@@ -37,10 +46,6 @@ export function expectType(
         )
       );
     } else if (!checker.isTypeIdenticalTo(expectedType, argumentType)) {
-      /**
-       * The expected type and argument type are assignable in both directions. We still have to check
-       * if the types are identical. See https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#3.11.2.
-       */
       tsdResults.push(
         toAssertionResult(
           node,

--- a/source/handleAssertions/index.ts
+++ b/source/handleAssertions/index.ts
@@ -1,6 +1,6 @@
 import type * as ts from "@tsd/typescript";
 import type { AssertionResult } from "../types";
-import { expectNotAssignable } from "./assignable";
+import { expectAssignable, expectNotAssignable } from "./assignable";
 import { expectDeprecated, expectNotDeprecated } from "./deprecated";
 import { expectType, expectNotType } from "./identical";
 
@@ -22,6 +22,7 @@ export type Handler = (
 const assertionHandlers = new Map<Assertion, Handler>([
   [Assertion.EXPECT_TYPE, expectType],
   [Assertion.EXPECT_NOT_TYPE, expectNotType],
+  [Assertion.EXPECT_ASSIGNABLE, expectAssignable],
   [Assertion.EXPECT_NOT_ASSIGNABLE, expectNotAssignable],
   [Assertion.EXPECT_DEPRECATED, expectDeprecated],
   [Assertion.EXPECT_NOT_DEPRECATED, expectNotDeprecated],

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -47,7 +47,7 @@ test("failing", () => {
       message:
         "Argument of type 'Date' is not assignable to parameter of type 'string'.",
       line: 5,
-      character: 20,
+      character: 1,
     },
     {
       message: "Expected an error, but found none.",
@@ -63,21 +63,21 @@ test("failing-nested", () => {
   expect(normalizeResults(tsdResults)).toMatchObject([
     {
       file: {
-        fileName: expect.stringContaining("index.test.ts"),
-      },
-      message:
-        "Argument of type 'number' is not assignable to parameter of type 'string'.",
-      line: 6,
-      character: 20,
-    },
-    {
-      file: {
         fileName: expect.stringContaining("nested.ts"),
       },
       message:
         "Argument of type 'number' is not assignable to parameter of type 'string'.",
       line: 5,
-      character: 20,
+      character: 1,
+    },
+    {
+      file: {
+        fileName: expect.stringContaining("index.test.ts"),
+      },
+      message:
+        "Argument of type 'number' is not assignable to parameter of type 'string'.",
+      line: 6,
+      character: 1,
     },
   ]);
 });

--- a/tests/assignable.test.ts
+++ b/tests/assignable.test.ts
@@ -10,7 +10,13 @@ test("expectAssignable", () => {
       message:
         "Argument of type 'string' is not assignable to parameter of type 'boolean'.",
       line: 10,
-      character: 27,
+      character: 1,
+    },
+    {
+      message:
+        "Argument of type '{ a: { b: number; }; }' is not assignable to parameter of type 'T2'.",
+      line: 13,
+      character: 1,
     },
   ]);
 });

--- a/tests/expectAssignable/index.test.ts
+++ b/tests/expectAssignable/index.test.ts
@@ -8,3 +8,6 @@ expectAssignable<string | number>(concat(1, 2));
 expectAssignable<any>(concat(1, 2));
 
 expectAssignable<boolean>(concat("unicorn", "rainbow"));
+
+type T2 = { a: { b: 1 } };
+expectAssignable<T2>({ a: { b: 1 } });

--- a/tests/expectNotAssignable/index.test.ts
+++ b/tests/expectNotAssignable/index.test.ts
@@ -8,3 +8,6 @@ expectNotAssignable<any>(concat("foo", "bar"));
 
 expectNotAssignable<boolean>(concat("unicorn", "rainbow"));
 expectNotAssignable<symbol>(concat("unicorn", "rainbow"));
+
+type T2 = { a: { b: 1 } };
+expectNotAssignable<T2>({ a: { b: 1 } });

--- a/tests/expectNotType/index.test.ts
+++ b/tests/expectNotType/index.test.ts
@@ -10,3 +10,6 @@ expectNotType<string>(concat("unicorn", "rainbow"));
 
 expectNotType<false>(concat("foo", "bar") as any);
 expectNotType<any>(concat("foo", "bar") as any);
+
+type T2 = { a: { b: 1 } };
+expectNotType<T2>({ a: { b: 1 } });

--- a/tests/expectType/index.test.ts
+++ b/tests/expectType/index.test.ts
@@ -13,3 +13,6 @@ expectType<false>(concat(1, 2) as any);
 
 expectType<string>("" as never);
 expectType<any>("" as never);
+
+type T2 = { a: { b: 1 } };
+expectType<T2>({ a: { b: 1 } });

--- a/tests/identical.test.ts
+++ b/tests/identical.test.ts
@@ -36,6 +36,12 @@ test("expectType", () => {
       line: 15,
       character: 1,
     },
+    {
+      message:
+        "Argument of type '{ a: { b: number; }; }' is not assignable to parameter of type 'T2'.",
+      line: 18,
+      character: 1,
+    },
   ]);
 });
 


### PR DESCRIPTION
Adds assertion logic for `expectAssignable` and `expectType` instead of a fall back on semantic diagnostics.