### PR TITLE
fix: add `ts2542` to the list of expected errors

### DIFF
--- a/.yarn/versions/e89abd7c.yml
+++ b/.yarn/versions/e89abd7c.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch

--- a/source/silenceError.ts
+++ b/source/silenceError.ts
@@ -5,8 +5,8 @@ import type { Location } from "./parser";
 // https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json
 
 const silencedErrors = [
-  2314, 2322, 2339, 2344, 2345, 2348, 2349, 2350, 2351, 2540, 2554, 2555, 2559,
-  2575, 2684, 2707, 2741, 2743, 2769, 2820, 4113, 4114, 7009,
+  2314, 2322, 2339, 2344, 2345, 2348, 2349, 2350, 2351, 2540, 2542, 2554, 2555,
+  2559, 2575, 2684, 2707, 2741, 2743, 2769, 2820, 4113, 4114, 7009,
 ];
 
 const topLevelAwaitErrors = [1308, 1378];

--- a/tests/expectError/index.test.ts
+++ b/tests/expectError/index.test.ts
@@ -100,3 +100,14 @@ expectError(fTwo("foo", "bar"));
 
 // Produces multiple type checker errors in a single `expectError` assertion
 expectError(fThree(["a", "bad"]));
+
+type StrictReadonlyValues = {
+  readonly [type: string]: ReadonlyArray<string>;
+};
+
+expectError(() => {
+  const readonlyValues: StrictReadonlyValues = {
+    someValue: ["south", "east"],
+  };
+  readonlyValues.someValue = ["north", "west"];
+});


### PR DESCRIPTION
Adding "ts2542: Index signature in type '{0}' only permits reading" to the list of expected errors.