### PR TITLE
fix: add ts2366 to the list of expected errors

### DIFF
--- a/.yarn/versions/325c64cf.yml
+++ b/.yarn/versions/325c64cf.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch

--- a/source/silenceError.ts
+++ b/source/silenceError.ts
@@ -5,8 +5,8 @@ import type { Location } from "./parser";
 // https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json
 
 const silencedErrors = [
-  2314, 2322, 2339, 2344, 2345, 2348, 2349, 2350, 2351, 2540, 2542, 2554, 2555,
-  2559, 2575, 2684, 2707, 2741, 2743, 2769, 2820, 4113, 4114, 7009,
+  2314, 2322, 2339, 2344, 2366, 2345, 2348, 2349, 2350, 2351, 2540, 2542, 2554,
+  2555, 2559, 2575, 2684, 2707, 2741, 2743, 2769, 2820, 4113, 4114, 7009,
 ];
 
 const topLevelAwaitErrors = [1308, 1378];

--- a/tests/expectError/index.test.ts
+++ b/tests/expectError/index.test.ts
@@ -111,3 +111,13 @@ expectError(() => {
   };
   readonlyValues.someValue = ["north", "west"];
 });
+
+expectError(() => {
+  function lacksElseBranch(arg: string): { pass: boolean } {
+    if (arg === "value") {
+      return {
+        pass: true,
+      };
+    }
+  }
+});


### PR DESCRIPTION
Adding "ts2366: Function lacks ending return statement and return type does not include 'undefined'" to the list of expected errors.