### PR TITLE
fix: expose `TsdResult` type

### DIFF
--- a/.yarn/versions/49f57b58.yml
+++ b/.yarn/versions/49f57b58.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch

--- a/source/index.ts
+++ b/source/index.ts
@@ -9,3 +9,5 @@ export {
   expectNotType,
   expectType,
 } from "./assertions";
+
+export type { TsdResult } from "./types";


### PR DESCRIPTION
Exposing `TsdResult` type is useful for type checking in third party implementations.