### PR TITLE
Add properties `bugs` and `homepage` and modify `repository`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "repository": "https://github.com/mrazauskas/tsd-lite.git",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "homepage": "https://github.com/mrazauskas/tsd-lite",
+  "bugs": {
+    "url": "https://github.com/mrazauskas/tsd-lite/issues"
+  },
   "engines": {
     "node": ">=12"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.5.4",
   "description": "Test your TypeScript types easily",
   "license": "MIT",
-  "repository": "https://github.com/mrazauskas/tsd-lite.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mrazauskas/tsd-lite.git"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "homepage": "https://github.com/mrazauskas/tsd-lite",


### PR DESCRIPTION
This changes that registries like npmjs will make it easier for finding the source of the project

will change from:
![from](https://user-images.githubusercontent.com/10911626/176436796-38f3368b-79be-4748-af19-dd6cbe24d5f8.png)

to something like typegoose has:
![change to](https://user-images.githubusercontent.com/10911626/176436831-144df690-342c-48da-a024-5c32fa29d2b1.png)
(only that for this project both links would be similar)