### PR TITLE
chore: drop Node v12 support

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/.yarn/versions/5e378b43.yml
+++ b/.yarn/versions/5e378b43.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor


### PR DESCRIPTION
Dropping Node v12. The just released Jest v29 does not support it anymore time to move on.