### PR TITLE
chore(ci): run tests on Node.js v19

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Adding Node.js v19 to CI workflow.