### PR TITLE
docs: add reference to "tsd-lite-cli" 3rd party library

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is a lighter version of [tsd](https://npmjs.com/package/tsd). Slightly reworked codebase allows `tsd-lite` to be a tool which simply tests your types.
 
-> **Note** This library is intended for programmatic use only. For CLI implementation see [`jest-runner-tsd`](https://github.com/jest-community/jest-runner-tsd).
+> **Note** This library is intended for programmatic use only. For CLI implementation see [`jest-runner-tsd`](https://github.com/jest-community/jest-runner-tsd) or [tsd-lite-cli](https://github.com/asd-xiv/tsd-lite-cli) for a standalone version.
 
 ## Motivation
 


### PR DESCRIPTION
Hello there, I was looking for a non-jest based way of running `test-d` files in a TS project and couldn't find anything so I put together a small standalone library with basic TAP output.

https://github.com/asd-xiv/tsd-lite-cli

I created a PR to add a link to it in your docs :vulcan_salute:  