### PR TITLE
fix: add ts2375, ts2379 and ts2412 to the list of expected errors

### DIFF
--- a/.yarn/versions/438b2de9.yml
+++ b/.yarn/versions/438b2de9.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch

--- a/source/silenceError.ts
+++ b/source/silenceError.ts
@@ -5,8 +5,9 @@ import type { Location } from "./parser";
 // https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json
 
 const silencedErrors = [
-  2314, 2322, 2339, 2344, 2366, 2345, 2348, 2349, 2350, 2351, 2540, 2542, 2554,
-  2555, 2559, 2575, 2684, 2707, 2741, 2743, 2769, 2820, 4113, 4114, 7009,
+  2314, 2322, 2339, 2344, 2366, 2345, 2348, 2349, 2350, 2351, 2375, 2379, 2412,
+  2540, 2542, 2554, 2555, 2559, 2575, 2684, 2707, 2741, 2743, 2769, 2820, 4113,
+  4114, 7009,
 ];
 
 const topLevelAwaitErrors = [1308, 1378];

--- a/tests/compilerOptions-exactOptionalPropertyTypes/index.d.ts
+++ b/tests/compilerOptions-exactOptionalPropertyTypes/index.d.ts
@@ -1,0 +1,6 @@
+export type OptionalProperty = {
+  requiredProp: "required";
+  optionalProp?: "optional";
+};
+
+export function setWithOptionalProperty(obj: OptionalProperty): unknown;

--- a/tests/compilerOptions-exactOptionalPropertyTypes/index.test.ts
+++ b/tests/compilerOptions-exactOptionalPropertyTypes/index.test.ts
@@ -1,0 +1,22 @@
+import { expectError } from "../../";
+import { OptionalProperty, setWithOptionalProperty } from ".";
+
+expectError(() => {
+  const obj: OptionalProperty = {
+    requiredProp: "required",
+    optionalProp: undefined,
+  };
+
+  console.log(obj);
+});
+
+expectError(
+  setWithOptionalProperty({
+    requiredProp: "required",
+    optionalProp: undefined,
+  })
+);
+
+const obj: OptionalProperty = { requiredProp: "required" };
+
+expectError((obj.optionalProp = undefined));

--- a/tests/compilerOptions-exactOptionalPropertyTypes/tsconfig.json
+++ b/tests/compilerOptions-exactOptionalPropertyTypes/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  }
+}

--- a/tests/compilerOptions.test.ts
+++ b/tests/compilerOptions.test.ts
@@ -14,6 +14,14 @@ test("`compilerOptions.strict` in nearest `tsconfig.json`", () => {
   expect(tsdResults).toHaveLength(0);
 });
 
+test("`compilerOptions.exactOptionalPropertyTypes` in nearest `tsconfig.json`", () => {
+  const { tsdResults } = tsd(
+    fixturePath("compilerOptions-exactOptionalPropertyTypes")
+  );
+
+  expect(tsdResults).toHaveLength(0);
+});
+
 test("when parsing `tsconfig.json` returns errors", () => {
   expect(() => {
     tsd(fixturePath("compilerOptions-errors"));


### PR DESCRIPTION
Adding error related with `compilerOptions.exactOptionalPropertyTypes` to the list of expected errors.