### PR TITLE
chore: declare Node.js v14 as lowest supported version

### DIFF
--- a/.yarn/versions/786b7b56.yml
+++ b/.yarn/versions/786b7b56.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tsd/typescript": "^3.8.3 || ^4.0.7"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "packageManager": "yarn@3.4.1"
 }


### PR DESCRIPTION
Currently `engines` has incorrect declaration.