### PR TITLE
refactor: remove redundant checks

### DIFF
--- a/source/handleAssertions/identical.ts
+++ b/source/handleAssertions/identical.ts
@@ -20,32 +20,7 @@ export function expectType(
     const expectedType = checker.getTypeFromTypeNode(node.typeArguments[0]);
     const argumentType = checker.getTypeAtLocation(node.arguments[0]);
 
-    if (!checker.isTypeAssignableTo(argumentType, expectedType)) {
-      tsdResults.push(
-        toAssertionResult(
-          node,
-          `Argument of type '${checker.typeToString(
-            argumentType
-          )}' is not assignable to parameter of type '${checker.typeToString(
-            expectedType
-          )}'.`
-        )
-      );
-      continue;
-    }
-
-    if (!checker.isTypeAssignableTo(expectedType, argumentType)) {
-      tsdResults.push(
-        toAssertionResult(
-          node,
-          `Parameter type '${checker.typeToString(
-            expectedType
-          )}' is declared too wide for argument type '${checker.typeToString(
-            argumentType
-          )}'.`
-        )
-      );
-    } else if (!checker.isTypeIdenticalTo(expectedType, argumentType)) {
+    if (!checker.isTypeIdenticalTo(expectedType, argumentType)) {
       tsdResults.push(
         toAssertionResult(
           node,

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -45,7 +45,7 @@ test("failing", () => {
   expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message:
-        "Argument of type 'Date' is not assignable to parameter of type 'string'.",
+        "Parameter type 'string' is not identical to argument type 'Date'.",
       line: 5,
       character: 1,
     },
@@ -66,7 +66,7 @@ test("failing-nested", () => {
         fileName: expect.stringContaining("nested.ts"),
       },
       message:
-        "Argument of type 'number' is not assignable to parameter of type 'string'.",
+        "Parameter type 'string' is not identical to argument type 'number'.",
       line: 5,
       character: 1,
     },
@@ -75,7 +75,7 @@ test("failing-nested", () => {
         fileName: expect.stringContaining("index.test.ts"),
       },
       message:
-        "Argument of type 'number' is not assignable to parameter of type 'string'.",
+        "Parameter type 'string' is not identical to argument type 'number'.",
       line: 6,
       character: 1,
     },

--- a/tests/identical.test.ts
+++ b/tests/identical.test.ts
@@ -14,7 +14,7 @@ test("expectType", () => {
     },
     {
       message:
-        "Parameter type 'string | number' is declared too wide for argument type 'string'.",
+        "Parameter type 'string | number' is not identical to argument type 'string'.",
       line: 10,
       character: 1,
     },
@@ -26,19 +26,19 @@ test("expectType", () => {
     },
     {
       message:
-        "Parameter type 'string' is declared too wide for argument type 'never'.",
+        "Parameter type 'string' is not identical to argument type 'never'.",
       line: 14,
       character: 1,
     },
     {
       message:
-        "Parameter type 'any' is declared too wide for argument type 'never'.",
+        "Parameter type 'any' is not identical to argument type 'never'.",
       line: 15,
       character: 1,
     },
     {
       message:
-        "Argument of type '{ a: { b: number; }; }' is not assignable to parameter of type 'T2'.",
+        "Parameter type 'T2' is not identical to argument type '{ a: { b: number; }; }'.",
       line: 18,
       character: 1,
     },


### PR DESCRIPTION
The `isTypeAssignableTo` checks are redundant before `isTypeIdenticalTo`. Having straight forward error message is also good idea.