### PR TITLE
chore: drop support for `@tsd/typescript` v3.x and add support for v5.x

### DIFF
--- a/.yarn/versions/503df5b8.yml
+++ b/.yarn/versions/503df5b8.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@tsd/typescript": "^3.8.3 || ^4.0.7"
+    "@tsd/typescript": "4.x || 5.x"
   },
   "engines": {
     "node": ">=14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,7 +5897,7 @@ __metadata:
     prettier: 2.8.4
     typescript: 4.9.5
   peerDependencies:
-    "@tsd/typescript": ^3.8.3 || ^4.0.7
+    "@tsd/typescript": 4.x || 5.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
It is time to drop support for `@tsd/typescript` v3.x; and to add support for soon to be released v5.x.