### PR TITLE
chore(ci): run tests on Node.js v20

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x]
+        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Run CI tests on Node.js v20.