### PR TITLE
chore: drop support for Node.js v14 and v19

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
     runs-on: ubuntu-latest
 
     steps:

--- a/.yarn/versions/a422cf76.yml
+++ b/.yarn/versions/a422cf76.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tsd/typescript": "4.x || 5.x"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "packageManager": "yarn@3.6.0"
 }


### PR DESCRIPTION
Dropping support for Node.js v14 and v19, because these are EOL (reference: the [release schedule](https://github.com/nodejs/release#release-schedule)).