### PR TITLE
chore: use `@tsconfig/node16` base

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "7.22.5",
     "@babel/preset-typescript": "7.22.5",
     "@jest/globals": "29.5.0",
+    "@tsconfig/node16": "1.0.4",
     "@tsd/typescript": "5.1.3",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",

--- a/tests/compilerOptions-errors/tsconfig.json
+++ b/tests/compilerOptions-errors/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2019",
     "strict": "yes",
     "noEmitOnError": true
   },

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,11 +1,7 @@
 {
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "strict": true,
-    "noImplicitOverride": true,
-    "skipLibCheck": true
+    "noImplicitOverride": true
   },
   "include": ["**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,12 @@
 {
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "outDir": "build",
-    "target": "ES2019",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "outDir": "./build",
     "declaration": true,
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+
     "noEmitOnError": true,
-    "forceConsistentCasingInFileNames": true
+    "noUnusedParameters": true,
+    "noUnusedLocals": true
   },
   "include": ["./source/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,6 +2270,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsconfig/node16@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@tsconfig/node16@npm:1.0.4"
+  checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
+  languageName: node
+  linkType: hard
+
 "@tsd/typescript@npm:5.1.3":
   version: 5.1.3
   resolution: "@tsd/typescript@npm:5.1.3"
@@ -5948,6 +5955,7 @@ __metadata:
     "@babel/preset-env": 7.22.5
     "@babel/preset-typescript": 7.22.5
     "@jest/globals": 29.5.0
+    "@tsconfig/node16": ^1.0.4
     "@tsd/typescript": 5.1.3
     "@typescript-eslint/eslint-plugin": 5.59.11
     "@typescript-eslint/parser": 5.59.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,7 +2270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:^1.0.4":
+"@tsconfig/node16@npm:1.0.4":
   version: 1.0.4
   resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
@@ -5955,7 +5955,7 @@ __metadata:
     "@babel/preset-env": 7.22.5
     "@babel/preset-typescript": 7.22.5
     "@jest/globals": 29.5.0
-    "@tsconfig/node16": ^1.0.4
+    "@tsconfig/node16": 1.0.4
     "@tsd/typescript": 5.1.3
     "@typescript-eslint/eslint-plugin": 5.59.11
     "@typescript-eslint/parser": 5.59.11


### PR DESCRIPTION
Use `@tsconfig/node16` base to simplify TSConfig files.