### PR TITLE
refactor!: remove the confusing `expectError()` type argument

### DIFF
--- a/.yarn/versions/8c05e69a.yml
+++ b/.yarn/versions/8c05e69a.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: minor

--- a/source/assertions.ts
+++ b/source/assertions.ts
@@ -31,4 +31,4 @@ export declare function expectNotAssignable<T>(value: unknown): void;
  *
  * @param value - Value that should be checked.
  */
-export declare function expectError<T = unknown>(value: T): void;
+export declare function expectError(value: unknown): void;

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -8,12 +8,7 @@ test("expectError", () => {
   expect(normalizeResults(tsdResults)).toMatchObject([
     {
       message: "Expected an error, but found none.",
-      line: 18,
-      character: 1,
-    },
-    {
-      message: "Expected an error, but found none.",
-      line: 97,
+      line: 94,
       character: 1,
     },
   ]);

--- a/tests/expectError/index.test.ts
+++ b/tests/expectError/index.test.ts
@@ -14,9 +14,6 @@ import { Foo } from "./classes";
 import gOne, { two as gTwo } from "./generics";
 import fOne, { fTwo, fThree } from "./functions";
 
-expectError<string>(1);
-expectError<string>("fo");
-
 expectError((foo.bar = "quux"));
 expectError(foo.quux);
 


### PR DESCRIPTION
Removing the `expectError()` assertion type argument:

1. Its functionality is questionable, because it does the same as `expectNotAssignable()` (to be precise, `expectNotAssignable()` exposed from `'tsd-lite'` ~~does this job better~~ is more predictable).
2. When `expectNotAssignable()` is used, the test becomes easier to understand.
3. The usage of the type argument is not documented by the authors of `tsd`.

---

Migration. Simply use `expectNotAssignable()` instead:

```diff
- expectError<PackageJSON>({
+ expectNotAssignable<PackageJSON>({
    filter: () => {},
  });
```
