### PR TITLE
chore: add missing '@types/node' dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
   "bugs": {
     "url": "https://github.com/mrazauskas/tsd-lite/issues"
   },
-  "license": "MIT",
-  "files": [
-    "build/**/*"
-  ],
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mrazauskas/tsd-lite.git"
   },
+  "license": "MIT",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "files": [
+    "build/**/*"
+  ],
   "scripts": {
     "build": "tsc",
     "lint": "yarn lint:cspell && yarn lint:eslint && yarn lint:prettier",
@@ -42,6 +42,7 @@
     "@jest/globals": "29.5.0",
     "@tsconfig/node16": "1.0.4",
     "@tsd/typescript": "5.1.3",
+    "@types/node": "20.3.1",
     "@typescript-eslint/eslint-plugin": "5.59.11",
     "@typescript-eslint/parser": "5.59.11",
     "babel-jest": "29.5.0",
@@ -55,8 +56,8 @@
   "peerDependencies": {
     "@tsd/typescript": "4.x || 5.x"
   },
+  "packageManager": "yarn@3.6.0",
   "engines": {
     "node": ">=16"
-  },
-  "packageManager": "yarn@3.6.0"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,6 +2373,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:20.3.1":
+  version: 20.3.1
+  resolution: "@types/node@npm:20.3.1"
+  checksum: 63a393ab6d947be17320817b35d7277ef03728e231558166ed07ee30b09fd7c08861be4d746f10fdc63ca7912e8cd023939d4eab887ff6580ff704ff24ed810c
+  languageName: node
+  linkType: hard
+
 "@types/prettier@npm:^2.1.5":
   version: 2.7.3
   resolution: "@types/prettier@npm:2.7.3"
@@ -5957,6 +5964,7 @@ __metadata:
     "@jest/globals": 29.5.0
     "@tsconfig/node16": 1.0.4
     "@tsd/typescript": 5.1.3
+    "@types/node": 20.3.1
     "@typescript-eslint/eslint-plugin": 5.59.11
     "@typescript-eslint/parser": 5.59.11
     babel-jest: 29.5.0


### PR DESCRIPTION
Adding the missing `'@types/node'` dev dependency. (Also ran `npx sort-package-json`.)