### PR TITLE
refactor: simplify constructor of the `TsdError` class

### DIFF
--- a/source/tsdLite.ts
+++ b/source/tsdLite.ts
@@ -31,14 +31,14 @@ export function tsdLite(testFilePath: string): {
   const syntacticDiagnostics = program.getSyntacticDiagnostics();
 
   if (syntacticDiagnostics.length !== 0) {
-    throw new TsdError(syntacticDiagnostics[0], "SyntaxError");
+    throw new TsdError("SyntaxError", syntacticDiagnostics[0]);
   }
 
   const semanticDiagnostics = program.getSemanticDiagnostics();
 
-  const typeChecker = program.getTypeChecker();
   const { assertions, assertionsCount } = extractAssertions(program);
 
+  const typeChecker = program.getTypeChecker();
   const assertionResults = handleAssertions(typeChecker, assertions);
 
   const expectedErrors = parseErrorAssertionToLocation(assertions);

--- a/source/utils/TsdError.ts
+++ b/source/utils/TsdError.ts
@@ -1,27 +1,23 @@
 import * as ts from "@tsd/typescript";
-import { isDiagnosticWithLocation } from "./isDiagnosticWithLocation";
 
-function formatMassageAndLocation(diagnostic: ts.Diagnostic): {
-  message: string;
-  location?: string;
-} {
-  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
-
-  if (isDiagnosticWithLocation(diagnostic)) {
-    const { file, start } = diagnostic;
-
-    const { line, character } = file.getLineAndCharacterOfPosition(start);
-    const location = `at ${file.fileName}:${line + 1}:${character + 1}`;
-
-    return { message, location };
-  }
-
-  return { message };
+export interface TsdErrorOptions {
+  file?: ts.SourceFile | undefined;
+  messageText: string | ts.DiagnosticMessageChain;
+  start?: number | undefined;
 }
 
 export class TsdError extends Error {
-  constructor(diagnostic: ts.Diagnostic, name: string) {
-    const { message, location } = formatMassageAndLocation(diagnostic);
+  constructor(name: string, options: TsdErrorOptions) {
+    let location: string | undefined;
+
+    if (options.file != null && options.start != null) {
+      const { line, character } = options.file.getLineAndCharacterOfPosition(
+        options.start
+      );
+      location = `at ${options.file.fileName}:${line + 1}:${character + 1}`;
+    }
+
+    const message = ts.flattenDiagnosticMessageText(options.messageText, "\n");
 
     super(message);
 

--- a/source/utils/resolveCompilerOptions.ts
+++ b/source/utils/resolveCompilerOptions.ts
@@ -23,7 +23,7 @@ export function resolveCompilerOptions(
     );
 
   if (configDiagnostics.length > 0) {
-    throw new TsdError(configDiagnostics[0], "ConfigError");
+    throw new TsdError("ConfigError", configDiagnostics[0]);
   }
 
   return compilerOptions;


### PR DESCRIPTION
The constructor of the `TsdError` class can be simplified for more flexible usage.