### PR TITLE
fix: error on imports from `'tsd'` package

### DIFF
--- a/.yarn/versions/60ec5113.yml
+++ b/.yarn/versions/60ec5113.yml
@@ -1,0 +1,2 @@
+releases:
+  tsd-lite: patch


### PR DESCRIPTION
This was overlooked in the initial release. `'tsd-lite'` must throw if an import from `'tsd'` package is encountered, because:

1. The typings and shape of testing APIs differ between the packages.
2. The APIs of `'tsd-lite'` do not suffer from bug like https://github.com/SamVerschueren/tsd/issues/142.
3. `'tsd-lite'` does not ship `'@tsd/typescript'` which is installed by `'tsd'`, but that is useless waste of disk space.
